### PR TITLE
Fixes Explore link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -61,6 +61,6 @@ documents:
   - title: Data & Visualization
     children:
       - title: Explore
-        url: /documents/16-Explore/
+        url: /documents/16-explore/
       - title: Push Button Acutations (Beta)
         url: /documents/push-button/


### PR DESCRIPTION
The [link](https://psutrec.github.io/documentation/documents/16-Explore/) in the sidebar navigation for the Explore page documentation is a 404 because the page name is lowercase but there is an uppercase letter in the link. This change replaces it with the [correct link](https://psutrec.github.io/documentation/documents/16-explore/).