### PR TITLE
Removes dead link from navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -31,8 +31,6 @@ documents:
         url: /documents/06-data/
       - title: "Parameter Definitions"
         url: /documents/07-parameter-definitions/
-      - title: "Adding Short Term or Manual Count Data"
-        url: /documents/12-manual-counts/
 #      - title: "Additional Resources"
 #        url: /documents/08-additional-resources/
 


### PR DESCRIPTION
The "Adding Short Term or Manual Count Data" page [was renamed](https://github.com/PSUTrec/documentation/commit/fe6386e8f0d9502cc8565e6dce974f05a977a717) to "Getting Started", and a new link was added to the navigation sidebar for it, but the [old link](https://psutrec.github.io/documentation/documents/12-manual-counts/) was never removed and is now a 404. This change removes the old link.